### PR TITLE
Minor cleanups

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -1,20 +1,19 @@
 ;;;; package.lisp
 
 (defpackage #:cl-soil
-  (:use #:cl :cffi)
-  (:export :load-ogl-texture
-           :load-ogl-texture-from-memory
-           :create-ogl-texture
-           :load-ogl-hdr-texture
-           :load-image
-           :load-image-from-memory
-           :save-image
-           :free-image-data
-           :load-ogl-cubemap
-           :load-ogl-cubemap-from-memory           
-           :load-ogl-single-cubemap
-           :load-ogl-single-cubemap-from-memory
-           :create-ogl-single-cubemap
-           :save-screenshot
-           :last-result))
-
+  (:use #:cl #:cffi)
+  (:export #:load-ogl-texture
+           #:load-ogl-texture-from-memory
+           #:create-ogl-texture
+           #:load-ogl-hdr-texture
+           #:load-image
+           #:load-image-from-memory
+           #:save-image
+           #:free-image-data
+           #:load-ogl-cubemap
+           #:load-ogl-cubemap-from-memory
+           #:load-ogl-single-cubemap
+           #:load-ogl-single-cubemap-from-memory
+           #:create-ogl-single-cubemap
+           #:save-screenshot
+           #:last-result))


### PR DESCRIPTION
Hi Baggers,

 Thanks for the library. The commit message gives the sum up of the changes. Only two are bugs proper. a misnamed function (the exported symbol was with #- not #_) and calling a cfun with an extra argument, force-channels.

```
* (cl-soil.lisp):
    - Use an interned symbol for package designator
    - handle-tex-flags: each loop statement in a new line (style change)
    - Rename create_ogl_single_cube to lispy style
    - Remove spurious argument, force-channels, in
      soil-create-ogl-single-cubemap
    - Return multiple values instead of a list of values in
      with-zero-being-an-error, load-image and load-image-from-memory

* (package.lisp): Replace keywords with uninterned symbols
```
